### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 [Model Context Protocol server](https://modelcontextprotocol.io/) for [YDB](https://ydb.tech). It allows to work with YDB databases from any [LLM](https://en.wikipedia.org/wiki/Large_language_model) that supports MCP. This integration enables AI-powered database operations and natural language interactions with your YDB instances.
 
+<a href="https://glama.ai/mcp/servers/@ydb-platform/ydb-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ydb-platform/ydb-mcp/badge" alt="YDB MCP server" />
+</a>
+
 ## Usage
 
 ### Via uvx


### PR DESCRIPTION
This PR adds a badge for the [YDB MCP](https://glama.ai/mcp/servers/@ydb-platform/ydb-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ydb-platform/ydb-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ydb-platform/ydb-mcp/badge" alt="YDB MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.